### PR TITLE
1.0.0 skip full cv total count

### DIFF
--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageProducers/EdFiApiChangeVersionPagingStreamResourcePageMessageProducer.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageProducers/EdFiApiChangeVersionPagingStreamResourcePageMessageProducer.cs
@@ -41,27 +41,27 @@ public class EdFiApiChangeVersionPagingStreamResourcePageMessageProducer : IStre
         }
 
         // Get total count of items in source resource for change window (if applicable)
-        var (totalCountSuccess, totalCount) = await _sourceTotalCountProvider.TryGetTotalCountAsync(
-            message.ResourceUrl,
-            options,
-            message.ChangeWindow,
-            errorHandlingBlock,
-            cancellationToken);
+        // var (totalCountSuccess, totalCount) = await _sourceTotalCountProvider.TryGetTotalCountAsync(
+        //     message.ResourceUrl,
+        //     options,
+        //     message.ChangeWindow,
+        //     errorHandlingBlock,
+        //     cancellationToken);
 
-        if (!totalCountSuccess)
-        {
-            // Allow processing to continue without performing additional work on this resource.
-            return Enumerable.Empty<StreamResourcePageMessage<TProcessDataMessage>>();
-        }
+        // if (!totalCountSuccess)
+        // {
+        //     // Allow processing to continue without performing additional work on this resource.
+        //     return Enumerable.Empty<StreamResourcePageMessage<TProcessDataMessage>>();
+        // }
 
-        _logger.Information($"{message.ResourceUrl}: Total count = {totalCount}");
+        // _logger.Information($"{message.ResourceUrl}: Total count = {totalCount}");
 
         int limit = message.PageSize;
 
         var pageMessages = new List<StreamResourcePageMessage<TProcessDataMessage>>();
         
-        if (totalCount > 0)
-        {
+        // if (totalCount > 0)
+        // {
             var noOfPartitions = Math.Ceiling((decimal)(message.ChangeWindow.MaxChangeVersion - message.ChangeWindow.MinChangeVersion)
                             / options.ChangeVersionPagingWindowSize);
 
@@ -129,7 +129,7 @@ public class EdFiApiChangeVersionPagingStreamResourcePageMessageProducer : IStre
                 changeVersionWindow++;
 
             }
-        }
+        // }
 
         // Flag the last page for special "continuation" processing
         if (pageMessages.Any())

--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageProducers/EdFiApiChangeVersionPagingStreamResourcePageMessageProducer.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Source/MessageProducers/EdFiApiChangeVersionPagingStreamResourcePageMessageProducer.cs
@@ -73,6 +73,7 @@ public class EdFiApiChangeVersionPagingStreamResourcePageMessageProducer : IStre
 
             int changeVersionWindow = 0;
             long changeVersionWindowStartValue = message.ChangeWindow.MinChangeVersion;
+            long totalCount = 0;
 
             while (changeVersionWindow < noOfPartitions)
             {
@@ -103,6 +104,7 @@ public class EdFiApiChangeVersionPagingStreamResourcePageMessageProducer : IStre
                     continue;
                 }
 
+                totalCount += totalCountOnWindow;
                 int offsetOnWindow = 0;
                 while (offsetOnWindow < totalCountOnWindow)
                 {
@@ -130,6 +132,8 @@ public class EdFiApiChangeVersionPagingStreamResourcePageMessageProducer : IStre
 
             }
         // }
+
+        _logger.Information($"{message.ResourceUrl}: Total count = {totalCount}");
 
         // Flag the last page for special "continuation" processing
         if (pageMessages.Any())


### PR DESCRIPTION
This PR addresses a bug with the change version "paging" strategy in API Publisher.  The intent of that functionality is to ensure that API Publisher never makes any requests larger than "ChangeVersionPagingWindowSize" to reduce load on the source Ed-Fi system.  When requesting records from resources, the code was using smaller change version windows as desired, but only after the API Publisher had retrieved totalCount for the entire change version window.  This request on it's own is enough to exceed the timeout of the source system in some cases.  The changes here remove this call, and instead retrieve the totalCount by iterating through each change version window.  