### PR TITLE
Namespace LastChangeVersionProcessed

### DIFF
--- a/docs/API-Publisher-Configuration.md
+++ b/docs/API-Publisher-Configuration.md
@@ -31,6 +31,7 @@ Defines general behavior of the Ed-Fi API Publisher.
 | Options:RateLimitTimeSeconds<br/>`--rateLimitTimeSeconds`                                                 | Indicates the  the time span for the rate limit in seconds.<br/>(_Default value: 1_) |
 | Options:RateLimitMaxRetries<br/>`--rateLimitMaxRetries`                                                   | Indicates the number of times the Ed-Fi API publisher will attempt to _resend_ a request, rejected by rate limiting, to the source or destination APIs before determining that the failure is permanent.<br/>(_Default value: 10_) |
 | Options:useReversePaging<br/>`--useReversePaging`                                                         | Indicates whether or not to use reverse paging mode. For more information about this feature read [here](Reverse-Paging.md).<br/>(_Default value: false_) |
+| Options:LastChangeVersionProcessedNamespace<br />`--lastChangeVersionProcessedNamespace`                  | Indicates the namespace for change version tracking.  If provided, this string will be prepended to the target name when reading and writing the lastChangeVersionsProcessed named connection parameter. |
 
 ## API Connections
 

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
@@ -99,6 +99,6 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
 
         public bool UseReversePaging { get; set; } = false;
 
-        public string JobName { get; set; }
+        public string LastChangeVersionProcessedNamespace { get; set; }
     }
 }

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
@@ -98,5 +98,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
         public int RateLimitMaxRetries { get; set; } = 5;
 
         public bool UseReversePaging { get; set; } = false;
+
+        public string JobName { get; set; }
     }
 }

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
@@ -77,7 +77,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
                     ["--rateLimitTimeSeconds"] = "Options:RateLimitTimeSeconds",
                     ["--rateLimitMaxRetries"] = "Options:RateLimitMaxRetries",
                     ["--useReversePaging"] = "Options:UseReversePaging",
-                    ["--jobName"] = "Options:JobName",
+                    ["--lastChangeVersionProcessedNamespace"] = "Options:LastChangeVersionProcessedNamespace",
 
 
                     // Resource selection (comma delimited paths - e.g. "/ed-fi/students,/ed-fi/studentSchoolAssociations")

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
@@ -77,6 +77,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
                     ["--rateLimitTimeSeconds"] = "Options:RateLimitTimeSeconds",
                     ["--rateLimitMaxRetries"] = "Options:RateLimitMaxRetries",
                     ["--useReversePaging"] = "Options:UseReversePaging",
+                    ["--jobName"] = "Options:JobName",
 
 
                     // Resource selection (comma delimited paths - e.g. "/ed-fi/students,/ed-fi/studentSchoolAssociations")

--- a/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
@@ -620,7 +620,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
             {
                 return _sourceConnectionDetails.LastChangeVersionProcessed.Value;
             }
-
+            
             // Fall back to using the pre-configured change version
             return _sourceConnectionDetails
                 .LastChangeVersionProcessedByTargetName

--- a/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
@@ -116,9 +116,9 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
                     || options.UseChangeVersionPaging)
                 {
                     _lcvpTargetName = _targetConnectionDetails.Name;
-                    if (!string.IsNullOrEmpty(options.JobName))
+                    if (!string.IsNullOrEmpty(options.LastChangeVersionProcessedNamespace))
                     {
-                        _lcvpTargetName = $"{options.JobName}:{_targetConnectionDetails.Name}";
+                        _lcvpTargetName = $"{options.LastChangeVersionProcessedNamespace}:{_targetConnectionDetails.Name}";
                     }
 
                     changeWindow = await EstablishChangeWindowAsync().ConfigureAwait(false);
@@ -620,7 +620,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
             {
                 return _sourceConnectionDetails.LastChangeVersionProcessed.Value;
             }
-            
+
             // Fall back to using the pre-configured change version
             return _sourceConnectionDetails
                 .LastChangeVersionProcessedByTargetName

--- a/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
@@ -225,7 +225,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
             var sinkDetails = _targetConnectionDetails;
             
             var configurationStoreSection = configuration.ConfigurationStoreSection;
-                        
+            
             // If we have a name for source and target connections, write the change version
             if (!string.IsNullOrEmpty(sourceDetails.Name)
                 && !string.IsNullOrEmpty(sinkDetails.Name))
@@ -620,7 +620,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
             {
                 return _sourceConnectionDetails.LastChangeVersionProcessed.Value;
             }
-
+            
             // Fall back to using the pre-configured change version
             return _sourceConnectionDetails
                 .LastChangeVersionProcessedByTargetName


### PR DESCRIPTION
This PR adds a new option to the API Publisher allowing for additional uniqueness when tracking the last change version processed.  When the options is provided, the API Publisher prefixes the provided value and a colon to the target connection name, as shown in the example below.  When the options is not provided, the original behavior is retained.

CLI argument `... --targetName=state-2425 --lastChangeVersionProcessedNamespace=something`
will associate last change version information with `something:state-2425`
which stores `{"something:state-2425":123456}` in the named connection provider's lastChangeVersionsProcessed parameter.

This is useful in situations where it is desired to use the same source and target connections for multiple configurations of the API Publisher.  For example, if it is desired to publish attendance at a different frequency than the rest of the resources, or if it is desired to publish frequently from a live source while publishing less frequently from a change-isolated source.  