### PR TITLE
Handle 0 value query parameter bug

### DIFF
--- a/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/DeleteResourceProcessingBlocksFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Connections.Api/Processing/Target/Blocks/DeleteResourceProcessingBlocksFactory.cs
@@ -175,12 +175,40 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                             return Enumerable.Empty<DeleteItemMessage>();
                         }
 
+                        // Check if any query parameter is 0.  If yes, perforform fuzzy match item selection.  If not, select the first item in the response list.
+                        bool hasZero = msg.KeyValues.OfType<JProperty>().Any(p =>
+                            (p.Value.Type == JTokenType.Integer || p.Value.Type == JTokenType.Float) &&
+                            (double)p.Value == 0);
+                        
+                        JObject matchingResult = null;
+
+                        if (hasZero) {
+                            _logger.Warning($"{msg.ResourceUrl} (source id: {msg.Id}): GET by key for deletion query included a 0 value.");
+                            // Find a result that matches the msg query...
+                            matchingResult = getByKeyResults
+                                .OfType<JObject>()
+                                .FirstOrDefault(item => MatchesQuery(item, msg));
+
+                            if (matchingResult == null) {
+                                _logger.Warning($"{msg.ResourceUrl} (source id: {msg.Id}): GET by key for deletion returned {getByKeyResults.Count} results on target API, and none matched. ({queryString})");
+
+                                return Enumerable.Empty<DeleteItemMessage>();
+                            }
+
+                            // Log the query string and selected id.
+                            _logger.Warning($"{msg.ResourceUrl} (source id: {msg.Id}): GET by key for deletion returned {getByKeyResults.Count} results on target API. ({queryString})");
+                            _logger.Warning($"{msg.ResourceUrl} (source id: {msg.Id}): GET by key for deletion selected {matchingResult["id"].Value<string>()} to be deleted. ({matchingResult.ToString()})");
+
+                        } else {
+                            matchingResult = getByKeyResults[0] as JObject;
+                        }
+
                         return new[]
                         {
                             new DeleteItemMessage
                             {
                                 ResourceUrl = msg.ResourceUrl,
-                                Id = getByKeyResults[0]["id"].Value<string>(),
+                                Id = matchingResult["id"].Value<string>(),
                                 SourceId = msg.Id,
                             }
                         };
@@ -223,6 +251,41 @@ namespace EdFi.Tools.ApiPublisher.Connections.Api.Processing.Target.Blocks
                         return property.Value.ToString();
                 }
             }
+        }
+
+        // Function to compare a returned item with expected values
+        private static bool MatchesQuery(JObject item, GetItemForDeletionMessage msg)
+        {
+            // Get all properties from the item that are strings or numbers
+            List<JProperty> ItemProperties = GetStringOrNumberProperties(item);
+
+            // Test that all properties from the query message are found in the item
+            bool allExist = msg.KeyValues.OfType<JProperty>().All(jp1 =>
+                ItemProperties.Any(jp2 => jp1.Name == jp2.Name && JToken.DeepEquals(jp1.Value, jp2.Value)));
+
+            return allExist;
+        }
+
+        private static List<JProperty> GetStringOrNumberProperties(JObject jObject)
+        {
+            List<JProperty> result = new List<JProperty>();
+
+            foreach (var property in jObject.Properties())
+            {
+                // Check the type of the value
+                if (property.Value.Type == JTokenType.String || property.Value.Type == JTokenType.Integer || property.Value.Type == JTokenType.Float)
+                {
+                    result.Add(property);
+                }
+                else if (property.Value.Type == JTokenType.Object)
+                {
+                    // Recursively process nested JObjects
+                    result.AddRange(GetStringOrNumberProperties((JObject)property.Value));
+                }
+                // Skip arrays and other types
+            }
+
+            return result;
         }
 
         private TransformManyBlock<DeleteItemMessage, ErrorItemMessage> CreateDeleteResourceBlock(


### PR DESCRIPTION
This PR addresses a bug in Ed-Fi where a GET query that includes a parameter value of `0` is not correctly handled.  In this condition, Ed-Fi ignores the parameter with value 0, and returns results as if the parameter had been omitted.  This can result in too many, and incorrect results being returned to API publisher when processing GET by key for deletes.  The API publisher previously assumed that there should only be 0 or 1 results provided in this process, because all identity key/value pairs had been provided in the query.  The Ed-Fi bug combined with the API Publisher assumption can result in API Publisher silently deleting the wrong records.  

While a fix for the Ed-Fi bug is pending, the code in this PR addresses the assumption.  In the case that the GET by key for deletes query includes a parameter value of `0`, this code ensures that all key value pairs from the query are found in the result before selecting an item for deletion. 

This code has been tested using a district from the TX Exchange, while publishing to a TX Exchange development environment.  In the tests, it was observed that the code correctly...
1. Bypasses the new fuzzy match logic when no query parameter value = `0`
2. Identifies when results returned do not match the query
3. Identifies a result that does match the query, and submits it for deletion.  