### PR TITLE
Add optional additional upsert after delete

### DIFF
--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ApiPublisherSettings.cs
@@ -100,5 +100,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
         public bool UseReversePaging { get; set; } = false;
 
         public string LastChangeVersionProcessedNamespace { get; set; }
+
+        public bool AdditionalUpsertAfterDelete { get; set; } = false;
     }
 }

--- a/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Configuration/ConfigurationBuilderFactory.cs
@@ -78,7 +78,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Configuration
                     ["--rateLimitMaxRetries"] = "Options:RateLimitMaxRetries",
                     ["--useReversePaging"] = "Options:UseReversePaging",
                     ["--lastChangeVersionProcessedNamespace"] = "Options:LastChangeVersionProcessedNamespace",
-
+                    ["--additionalUpsertAfterDelete"] = "Options:AdditionalUpsertAfterDelete",
 
                     // Resource selection (comma delimited paths - e.g. "/ed-fi/students,/ed-fi/studentSchoolAssociations")
                     ["--include"] = "Connections:Source:Include",

--- a/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
+++ b/src/EdFi.Tools.ApiPublisher.Core/Processing/ChangeProcessor.cs
@@ -176,6 +176,19 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
                     cancellationToken)
                     .ConfigureAwait(false);
 
+                // Process all the "Upserts" again to work around schrodingers resources issue
+                TaskStatus[] repostTaskStatuses = null;
+                if (options.AdditionalUpsertAfterDelete) {
+                    repostTaskStatuses = ProcessUpsertsToCompletion(
+                        dependencyKeysByResourceKey, 
+                        options,
+                        authorizationFailureHandling,
+                        changeWindow, 
+                        publishErrorsIngestionBlock,
+                        javascriptModuleFactory,
+                        cancellationToken);
+                }
+
                 // Indicate to the error handling that we're done feeding it errors.
                 publishErrorsIngestionBlock.Complete();
                 
@@ -183,7 +196,7 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
                 _logger.Debug($"Waiting for all errors to be published.");
                 publishErrorsCompletionBlock.Completion.Wait();
 
-                EnsureProcessingWasSuccessful(keyChangesTaskStatuses, postTaskStatuses, deleteTaskStatuses);
+                EnsureProcessingWasSuccessful(keyChangesTaskStatuses, postTaskStatuses, deleteTaskStatuses, repostTaskStatuses);
 
                 // Perform processing finalization activities
                 var finalizationTasks = _finalizationActivities.Select(f => f.Execute()).ToArray();
@@ -913,7 +926,8 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
         private void EnsureProcessingWasSuccessful(
             TaskStatus[] keyChangeTaskStatuses,
             TaskStatus[] postTaskStatuses,
-            TaskStatus[] deleteTaskStatuses)
+            TaskStatus[] deleteTaskStatuses,
+            TaskStatus[] repostTaskStatuses)
         {
             bool success = true;
             
@@ -947,6 +961,16 @@ namespace EdFi.Tools.ApiPublisher.Core.Processing
             {
                 success = false;
                 _logger.Error($"{nonCompletedDeleteTaskCount} resource delete tasks did not run to completion successfully -- last change version processed will not be updated for this connection.");
+            }
+
+            if (repostTaskStatuses != null){
+                var nonCompletedRepostTaskCount = repostTaskStatuses.Count(s => s != TaskStatus.RanToCompletion);
+
+                if (nonCompletedRepostTaskCount > 0)
+                {
+                    success = false;
+                    _logger.Error($"{nonCompletedRepostTaskCount} resource re-upsert tasks did not run to completion successfully -- last change version processed will not be updated for this connection.");
+                }
             }
 
             if (!success)


### PR DESCRIPTION
This PR adds a temporary workaround for the Schrodinger's resource issue.  The workaround is a simple, brute force replay of all upserts a second time, following the delete stage of the publisher.  This behavior is off by default, and can be enabled with `--additionalUpsertAfterDelete=true`.  It is not intended for this to be a long term feature of the API Publisher.  It is only a temporary measure until Ed-Fi systems are upgraded to 7.1 patch 3, or 7.3.  